### PR TITLE
Add lawyer account management

### DIFF
--- a/admin/admin.html
+++ b/admin/admin.html
@@ -14,6 +14,7 @@
     <nav>
       <strong>Panel de administración</strong>
       <ul>
+        <li><a href="/legal-landing/admin/users.html">Usuarios</a></li>
         <li><button id="btn-logout" class="secondary btn-secondary">Cerrar sesión</button></li>
       </ul>
     </nav>

--- a/admin/users.html
+++ b/admin/users.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="es" class="no-js">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Usuarios | Admin Leads</title>
+
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
+  <link rel="stylesheet" href="/legal-landing/assets/css/styles.css?v=23">
+</head>
+<body>
+  <header class="container site-header" style="margin-top:1rem">
+    <nav>
+      <strong>Panel de administración</strong>
+      <ul>
+        <li><a href="/legal-landing/admin/admin.html">Inicio</a></li>
+        <li><button id="btn-logout" class="secondary btn-secondary">Cerrar sesión</button></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main class="container" style="margin-top:1rem">
+    <section class="form-card">
+      <h2 class="form-title">Usuarios</h2>
+      <p class="form-desc">Crear cuentas para colaboradores.</p>
+
+      <form id="user-form">
+        <fieldset class="floating">
+          <input id="new-username" name="new-username" placeholder="abogado@ejemplo.com" required>
+          <label for="new-username">Usuario</label>
+        </fieldset>
+        <fieldset class="floating">
+          <input id="new-password" name="new-password" type="password" placeholder="••••••" required>
+          <label for="new-password">Contraseña</label>
+        </fieldset>
+        <button class="primary" type="submit">Crear usuario</button>
+        <small id="user-status" class="error" aria-live="polite"></small>
+      </form>
+
+      <hr>
+
+      <h3>Usuarios existentes</h3>
+      <div class="table-responsive">
+        <table role="grid">
+          <thead><tr><th>Usuario</th></tr></thead>
+          <tbody id="users-body"></tbody>
+        </table>
+      </div>
+    </section>
+  </main>
+
+  <script defer src="/legal-landing/assets/js/users.js?v=23"></script>
+</body>
+</html>

--- a/assets/js/users.js
+++ b/assets/js/users.js
@@ -1,0 +1,58 @@
+// Configura la URL base de tu Worker API:
+const CF_API_BASE = "https://lead-api.ismael-guijarro-raissouni.workers.dev";
+
+const q = (s) => document.querySelector(s);
+const usersBody = q('#users-body');
+const statusEl = q('#user-status');
+const form = q('#user-form');
+
+async function fetchJSON(url, opts = {}) {
+  const res = await fetch(url, { credentials: 'include', ...opts });
+  if (res.status === 401) { location.href = 'login.html'; return {}; }
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(data.error || 'ERROR');
+  return data;
+}
+
+async function loadUsers() {
+  const data = await fetchJSON(`${CF_API_BASE}/api/admin/users`);
+  usersBody.innerHTML = '';
+  (data.users || []).forEach(u => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${u.username}</td>`;
+    usersBody.appendChild(tr);
+  });
+}
+
+async function createUser(e) {
+  e.preventDefault();
+  statusEl.textContent = '';
+  const username = q('#new-username').value.trim();
+  const password = q('#new-password').value.trim();
+  if (!username || !password) { statusEl.textContent = 'Rellena usuario y contraseña.'; return; }
+  try {
+    await fetchJSON(`${CF_API_BASE}/api/admin/users`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+    q('#new-username').value = '';
+    q('#new-password').value = '';
+    statusEl.textContent = 'Usuario creado ✓';
+    statusEl.style.color = '#0f5132';
+    await loadUsers();
+  } catch {
+    statusEl.textContent = 'Error creando usuario';
+  }
+}
+
+q('#btn-logout').addEventListener('click', async () => {
+  await fetch(`${CF_API_BASE}/api/auth/logout`, { method: 'POST', credentials: 'include' });
+  location.href = 'login.html';
+});
+
+form.addEventListener('submit', createUser);
+
+(async function(){
+  try { await loadUsers(); } catch(e){}
+})();

--- a/migrations/002_users.sql
+++ b/migrations/002_users.sql
@@ -1,0 +1,8 @@
+-- Tabla de usuarios para abogados
+PRAGMA foreign_keys=ON;
+
+CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username TEXT NOT NULL UNIQUE,
+  pass_hash TEXT NOT NULL
+);


### PR DESCRIPTION
## Summary
- allow authentication using stored users in D1 database
- expose admin API to list, create and delete users
- add admin page and script to create lawyer accounts
- fix admin navigation links to use absolute paths so the users page is reachable on GitHub Pages
- add cache-busting parameter to users.js script on users page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ee6d2f0883339959cd20a13aaab3