### PR TITLE
Mostrar campos del formulario uno a uno

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -79,11 +79,13 @@ const API_URL = "https://lead-api.ismael-guijarro-raissouni.workers.dev"; // ←
   };
 
   // Stepper helpers
-  function showStep(i) {
+  function showStep(i, skipFocus = false) {
     steps.forEach((s, idx) => {
-      s.classList.toggle("is-active", idx === i);
+      const isActive = idx === i;
+      s.classList.toggle("is-active", isActive);
       s.classList.toggle("is-complete", idx < i);
-      s.setAttribute("aria-expanded", idx === i ? "true" : "false");
+      s.setAttribute("aria-expanded", isActive ? "true" : "false");
+      s.hidden = !isActive;
     });
     const progressBar = document.querySelector('.step-progress-bar');
     if (progressBar) {
@@ -91,10 +93,14 @@ const API_URL = "https://lead-api.ismael-guijarro-raissouni.workers.dev"; // ←
       progressBar.style.width = `${percent}%`;
     }
     activeIndex = i;
-    const focusable = steps[i].querySelector("input, select, textarea, button");
-    if (focusable) focusable.focus({ preventScroll: true });
-    steps[i].scrollIntoView({ behavior: "smooth", block: "center" });
+    if (!skipFocus) {
+      const focusable = steps[i].querySelector("input, select, textarea, button");
+      if (focusable) focusable.focus({ preventScroll: true });
+      steps[i].scrollIntoView({ behavior: "smooth", block: "center" });
+    }
   }
+
+  showStep(activeIndex, true);
 
   function validateStep1() {
     const digits = onlyDigits(phone.value);

--- a/index.html
+++ b/index.html
@@ -126,7 +126,7 @@
               </section>
 
               <!-- ÉTAPE 2 -->
-              <section class="step" role="group" aria-labelledby="s2-title">
+              <section class="step" role="group" aria-labelledby="s2-title" hidden>
                 <header class="step-header">
                   <span class="step-index" aria-hidden="true">2</span>
                   <svg aria-hidden="true" class="step-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 1 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>
@@ -156,7 +156,7 @@
               </section>
 
               <!-- ÉTAPE 3 -->
-              <section class="step" role="group" aria-labelledby="s3-title">
+              <section class="step" role="group" aria-labelledby="s3-title" hidden>
                 <header class="step-header">
                   <span class="step-index" aria-hidden="true">3</span>
                   <svg aria-hidden="true" class="step-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><line x1="10" y1="9" x2="8" y2="9"/></svg>


### PR DESCRIPTION
## Summary
- Oculta los pasos 2 y 3 hasta que el usuario avance en el formulario
- Actualiza el stepper para alternar la visibilidad de cada paso

## Testing
- `npm test` *(falla: no se encontró package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f9e241a8833381b7feb76d4f0278